### PR TITLE
Add a rule to enforce [] array syntax, make PHP version consistent

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -19,7 +19,7 @@
 		</properties>
 	</rule>
 	<rule ref="PHPCompatibilityWP" />
-	<config name="testVersion" value="7.2-" />
+	<config name="testVersion" value="7.3-" />
 
 	<rule ref="Generic.Arrays.DisallowLongArraySyntax.Found" />
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -21,6 +21,8 @@
 	<rule ref="PHPCompatibilityWP" />
 	<config name="testVersion" value="7.2-" />
 
+	<rule ref="Generic.Arrays.DisallowLongArraySyntax.Found" />
+
 	<file>.</file>
 
 	<exclude-pattern>/node_modules/</exclude-pattern>


### PR DESCRIPTION
* Some candidates have been confused about the type of array syntax the project should use.
* This makes it more clear that we're using `[]`, not `array()`
* Also, this bumps the PHP version in `phpcs.xml.dist` to `7.3`, to be consistent with `composer.json` and `README.md`