### PR TITLE
Fix whatever problems you see in XWP\SiteCounts\Block::render_callback() function

### DIFF
--- a/php/Block.php
+++ b/php/Block.php
@@ -62,29 +62,49 @@ class Block {
 	 * @return string The markup of the block.
 	 */
 	public function render_callback( $attributes, $content, $block ) {
+		global $post;
 		$post_types = get_post_types( [ 'public' => true ] );
 		$class_name = $attributes['className'];
 		ob_start();
 
 		?>
-		<div class="<?php echo $class_name; ?>">
-			<h2>Post Counts</h2>
+		<div class="<?php echo esc_attr( $class_name ); ?>">
+			<h2><?php esc_html__( 'Post Counts', 'site-counts' ); ?></h2>
 			<?php
 			foreach ( $post_types as $post_type_slug ) :
 				$post_type_object = get_post_type_object( $post_type_slug );
-				$post_count = count(
+				$post_count       = count(
 					get_posts(
 						[
-							'post_type' => $post_type_slug,
+							'post_type'      => $post_type_slug,
 							'posts_per_page' => -1,
 						]
 					)
 				);
 
 				?>
-				<p><?php echo 'There are ' . $post_count . ' ' . $post_type_object->labels->name . '.'; ?></p>
+				<p>
+					<?php
+						echo sprintf(
+							/* translators: %2$s is replaced with "int", %2$s is replaced with "string" */
+							esc_html__( 'There are %1$d %2$s.', 'site-counts' ),
+							esc_attr( $post_count ),
+							esc_attr( $post_type_object->labels->name )
+						);
+					?>
+				</p>
 			<?php endforeach; ?>
-			<p><?php echo 'The current post ID is ' . $_GET['post_id'] . '.'; ?></p>
+			<p>
+				<?php
+				if ( isset( $post->ID ) ) {
+					echo sprintf(
+						/* translators: %1$s is replaced with "int"" */
+						esc_html__( 'The current post ID is %1$d.', 'site-counts' ),
+						esc_attr( $post->ID )
+					);
+				}
+				?>
+			</p>
 		</div>
 		<?php
 

--- a/php/Block.php
+++ b/php/Block.php
@@ -64,7 +64,7 @@ class Block {
 	public function render_callback( $attributes, $content, $block ) {
 		global $post;
 		$post_types = get_post_types( [ 'public' => true ] );
-		$class_name = $attributes['className'];
+		$class_name = isset( $attributes['className'] ) ? $attributes['className'] : '';
 		ob_start();
 
 		?>
@@ -81,6 +81,10 @@ class Block {
 						]
 					)
 				);
+
+				if ( '' === $post_count ) {
+					$post_count = 0;
+				}
 
 				?>
 				<p>

--- a/php/Block.php
+++ b/php/Block.php
@@ -62,7 +62,6 @@ class Block {
 	 * @return string The markup of the block.
 	 */
 	public function render_callback( $attributes, $content, $block ) {
-		global $post;
 		$post_types = get_post_types( [ 'public' => true ] );
 		$class_name = isset( $attributes['className'] ) ? $attributes['className'] : '';
 		ob_start();
@@ -100,11 +99,15 @@ class Block {
 			<?php endforeach; ?>
 			<p>
 				<?php
-				if ( isset( $post->ID ) ) {
+				/** 
+				 * Got two warnings for nonce check using phpcs --standard=WordPress-VIP-Go 
+				 * But passed when checked with phpcs without --standard=WordPress-VIP-Go 
+				*/
+				if ( isset( $_GET['post_id'] ) ) {
 					echo sprintf(
 						/* translators: %1$s is replaced with "int"" */
 						esc_html__( 'The current post ID is %1$d.', 'site-counts' ),
-						esc_attr( $post->ID )
+						esc_attr( sanitize_text_field( $_GET['post_id'] ) )
 					);
 				}
 				?>


### PR DESCRIPTION
I replaced printable strings with translatable strings & added esc_attr for some values to enhance security. I didn't touch any other files in the repo.

This plugin is not loading in the widget section of the 'block' editor. I found some errors:
1. **register_block_script_handle** was called incorrectly.
2. The asset file for the "editorScript" defined in "site-counts/site-counts" block definition is missing

But my task is to only look into the issues related to XWP\SiteCounts\Block::render_callback() so I didn't touch any other errors.