### PR TITLE
Performance & security review

### DIFF
--- a/php/Block.php
+++ b/php/Block.php
@@ -87,7 +87,7 @@ class Block {
 				<li>
 				<?php
 				echo sprintf(
-					'There are %d %s.',
+					__( 'There are %d %s.', 'site-counts' ),
 					intval( $post_count ),
 					esc_html( $post_type_object->labels->name )
 				);
@@ -96,7 +96,7 @@ class Block {
 			<?php endforeach; ?>
 			</ul>
 			<p><?php echo sprintf(
-					'The current post ID is %d.',
+					__( 'The current post ID is %d.', 'site-counts' ),
 					intval( $_GET['post_id'] )
 			); ?></p>
 
@@ -124,7 +124,7 @@ class Block {
 
 			if ( $query->found_posts ) :
 				?>
-				<h2>Any 5 posts with the tag of foo and the category of baz</h2>
+				<h2><?php _e( 'Any 5 posts with the tag of foo and the category of baz', 'site-counts' ); ?></h2>
 				<ul>
 				<?php
 

--- a/php/Block.php
+++ b/php/Block.php
@@ -68,8 +68,8 @@ class Block {
 		ob_start();
 
 		?>
-			<div class="<?php echo $class_name; ?>">
-			<h2>Post Counts</h2>
+			<div class="<?php echo esc_attr( $class_name ); ?>">
+			<h2><?php esc_html_e( 'Post Counts', 'site-counts' ); ?></h2>
 			<ul>
 			<?php
 			foreach ( $post_types as $post_type_slug ) :
@@ -86,11 +86,19 @@ class Block {
 				?>
 				<li>
 				<?php
-				echo 'There are ' . $post_count . ' ' . $post_type_object->labels->name . '.';
+				echo sprintf(
+					'There are %d %s.',
+					intval( $post_count ),
+					esc_html( $post_type_object->labels->name )
+				);
 				?>
 				</li>
 			<?php endforeach; ?>
-			</ul><p><?php echo 'The current post ID is ' . $_GET['post_id'] . '.'; ?></p>
+			</ul>
+			<p><?php echo sprintf(
+					'The current post ID is %d.',
+					intval( $_GET['post_id'] )
+			); ?></p>
 
 			<?php
 			$query = new WP_Query(
@@ -122,7 +130,7 @@ class Block {
 
 				foreach ( array_slice( $query->posts, 0, 5 ) as $post ) :
 					?>
-					<li><?php echo $post->post_title; ?></li>
+					<li><?php esc_html_e( $post->post_title ); ?></li>
 					<?php
 				endforeach;
 			endif;

--- a/php/Block.php
+++ b/php/Block.php
@@ -65,6 +65,14 @@ class Block {
 	public function render_callback( $attributes, $content, $block ) {
 		$post_types = get_post_types( [ 'public' => true ] );
 		$class_name = $attributes['className'];
+
+		// Construct a cache key from the arguments and then check if a cache exists with that key. If it does, we can
+		// return cached output and avoid some querying which will be nice.
+		$cache_key = md5( json_encode( $post_types, $class_name ) );
+		if ( $output = wp_cache_get( $cache_key, 'site-counts' ) ) {
+			return $output;
+		}
+
 		ob_start();
 
 		?>
@@ -183,6 +191,10 @@ class Block {
 		</div>
 		<?php
 
-		return ob_get_clean();
+		// Get and cache the output so we can avoid unnecessary queries.
+		$output = ob_get_clean();
+		wp_cache_set( $cache_key, $output, 'site-counts', 5 * MINUTE_IN_SECONDS );
+
+		return $output;
 	}
 }

--- a/php/Block.php
+++ b/php/Block.php
@@ -155,8 +155,8 @@ class Block {
 					$post_meta = get_post_meta( get_the_ID() );
 					foreach ( $post_meta as $key => $value ) {
 						if (
-							( is_array( $value ) && array_search( 'Accepted', $value ) ) ||
-							'Accepted' == $value
+							( is_array( $value ) && array_search( 'Accepted', $value, true ) ) ||
+							'Accepted' === $value
 						) {
 							continue 2; // Skip this post in the loop.
 						}

--- a/php/Block.php
+++ b/php/Block.php
@@ -131,21 +131,16 @@ class Block {
 							'include_children' => false,
 						],
 					],
-					'meta_value'     => 'Accepted',
 				]
 			);
 
-			// Record the ID of the post we're on so we can exclude it from the output.
+			// Record the ID of the post we're on, so we can exclude it from the output.
 			$host_post_id = get_the_ID();
 
 			// Holding array for our post titles.
 			$post_titles = [];
 
 			if ( $query->have_posts() ) :
-				?>
-				<h2><?php _e( 'Any 5 posts with the tag of foo and the category of baz', 'site-counts' ); ?></h2>
-				<ul>
-				<?php
 				while ( $query->have_posts() ) :
 
 					$query->the_post();
@@ -155,17 +150,36 @@ class Block {
 						continue;
 					}
 
-					// Store the post title for later.
-					$post_titles[] = $post->post_title;
+					// Get all the post meta, so we can search it for any value of "Accepted", and skip any post with a
+					// matching meta value.
+					$post_meta = get_post_meta( get_the_ID() );
+					foreach ( $post_meta as $key => $value ) {
+						if (
+							( is_array( $value ) && array_search( 'Accepted', $value ) ) ||
+							'Accepted' == $value
+						) {
+							continue 2; // Skip this post in the loop.
+						}
+					}
 
-					foreach ( array_slice( $post_titles, 0, 5 ) as $title ) :
+					// Store the post title for later.
+					$post_titles[] = get_the_title();
+
+				endwhile;
+			endif;
+
+			// Print out the 5 post titles we actually need.
+			?>
+				<h2><?php _e( 'Any 5 posts with the tag of foo and the category of baz', 'site-counts' ); ?></h2>
+				<ul>
+					<?php
+					foreach ( array_slice( $post_titles, 0, 5 ) as $title ) {
 						?>
 						<li><?php esc_html( $title ); ?></li>
 						<?php
-				endwhile;
-			endif;
-			?>
-			</ul>
+					}
+					?>
+				</ul>
 		</div>
 		<?php
 

--- a/php/Block.php
+++ b/php/Block.php
@@ -74,14 +74,7 @@ class Block {
 			<?php
 			foreach ( $post_types as $post_type_slug ) :
 				$post_type_object = get_post_type_object( $post_type_slug );
-				$post_count       = count(
-					get_posts(
-						[
-							'post_type'      => $post_type_slug,
-							'posts_per_page' => -1,
-						]
-					)
-				);
+				$post_count       = count( wp_count_posts( $post_type_slug ) );
 
 				?>
 				<li>

--- a/php/Block.php
+++ b/php/Block.php
@@ -81,18 +81,25 @@ class Block {
 				<?php
 				echo sprintf(
 					/* translators: first replacement is number of posts, second replacement is the post type name (e.g. "post" ) */
-					__( 'There are %d %s.', 'site-counts' ),
+					__( 'There are %1$d %2$s.', 'site-counts' ),
 					intval( $post_count ),
 					esc_html( $post_type_object->labels->name )
 				);
 				?>
 				</li>
-			<?php endforeach; ?>
+				<?php
+				endforeach;
+			?>
 			</ul>
-			<p><?php echo sprintf(
+			<p>
+				<?php
+				echo sprintf(
+					/* translators: replacement will be a numeric post ID number */
 					__( 'The current post ID is %d.', 'site-counts' ),
 					intval( $_GET['post_id'] )
-			); ?></p>
+				);
+				?>
+			</p>
 
 			<?php
 			$query = new WP_Query(
@@ -124,7 +131,7 @@ class Block {
 
 				foreach ( array_slice( $query->posts, 0, 5 ) as $post ) :
 					?>
-					<li><?php esc_html_e( $post->post_title ); ?></li>
+					<li><?php esc_html( $post->post_title ); ?></li>
 					<?php
 				endforeach;
 			endif;

--- a/php/Block.php
+++ b/php/Block.php
@@ -87,6 +87,7 @@ class Block {
 				<li>
 				<?php
 				echo sprintf(
+					/* translators: first replacement is number of posts, second replacement is the post type name (e.g. "post" ) */
 					__( 'There are %d %s.', 'site-counts' ),
 					intval( $post_count ),
 					esc_html( $post_type_object->labels->name )

--- a/php/Block.php
+++ b/php/Block.php
@@ -104,9 +104,9 @@ class Block {
 			<?php
 			$query = new WP_Query(
 				[
-					'post_type'     => [ 'post', 'page' ],
-					'post_status'   => 'any',
-					'date_query'    => [
+					'post_type'    => [ 'post', 'page' ],
+					'post_status'  => 'any',
+					'date_query'   => [
 						[
 							'hour'    => 9,
 							'compare' => '>=',
@@ -116,10 +116,22 @@ class Block {
 							'compare' => '<=',
 						],
 					],
-					'tag'           => 'foo',
-					'category_name' => 'baz',
-					'post__not_in'  => [ get_the_ID() ],
-					'meta_value'    => 'Accepted',
+					'tax_query'    => [
+						'relation' => 'AND',
+						[
+							'taxonomy' => 'post_tag',
+							'field'    => 'slug',
+							'terms'    => [ 'foo' ],
+						],
+						[
+							'taxonomy'         => 'category',
+							'field'            => 'name',
+							'terms'            => [ 'baz' ],
+							'include_children' => false,
+						],
+					],
+					'post__not_in' => [ get_the_ID() ],
+					'meta_value'   => 'Accepted',
 				]
 			);
 

--- a/php/Block.php
+++ b/php/Block.php
@@ -63,63 +63,70 @@ class Block {
 	 * @return string The markup of the block.
 	 */
 	public function render_callback( $attributes, $content, $block ) {
-		$post_types = get_post_types(  [ 'public' => true ] );
+		$post_types = get_post_types( [ 'public' => true ] );
 		$class_name = $attributes['className'];
 		ob_start();
 
 		?>
-        <div class="<?php echo $class_name; ?>">
+			<div class="<?php echo $class_name; ?>">
 			<h2>Post Counts</h2>
 			<ul>
 			<?php
 			foreach ( $post_types as $post_type_slug ) :
-                $post_type_object = get_post_type_object( $post_type_slug  );
-                $post_count = count(
-                    get_posts(
+				$post_type_object = get_post_type_object( $post_type_slug );
+				$post_count       = count(
+					get_posts(
 						[
-							'post_type' => $post_type_slug,
+							'post_type'      => $post_type_slug,
 							'posts_per_page' => -1,
 						]
 					)
-                );
+				);
 
 				?>
-				<li><?php echo 'There are ' . $post_count . ' ' .
-					  $post_type_object->labels->name . '.'; ?></li>
-			<?php endforeach;	?>
+				<li>
+				<?php
+				echo 'There are ' . $post_count . ' ' . $post_type_object->labels->name . '.';
+				?>
+				</li>
+			<?php endforeach; ?>
 			</ul><p><?php echo 'The current post ID is ' . $_GET['post_id'] . '.'; ?></p>
 
 			<?php
-			$query = new WP_Query(  array(
-				'post_type' => ['post', 'page'],
-				'post_status' => 'any',
-				'date_query' => array(
-					array(
-						'hour'      => 9,
-						'compare'   => '>=',
-					),
-					array(
-						'hour' => 17,
-						'compare'=> '<=',
-					),
-				),
-                'tag'  => 'foo',
-                'category_name'  => 'baz',
-				  'post__not_in' => [ get_the_ID() ],
-				  'meta_value' => 'Accepted',
-			));
+			$query = new WP_Query(
+				[
+					'post_type'     => [ 'post', 'page' ],
+					'post_status'   => 'any',
+					'date_query'    => [
+						[
+							'hour'    => 9,
+							'compare' => '>=',
+						],
+						[
+							'hour'    => 17,
+							'compare' => '<=',
+						],
+					],
+					'tag'           => 'foo',
+					'category_name' => 'baz',
+					'post__not_in'  => [ get_the_ID() ],
+					'meta_value'    => 'Accepted',
+				]
+			);
 
 			if ( $query->found_posts ) :
 				?>
-				 <h2>Any 5 posts with the tag of foo and the category of baz</h2>
-                <ul>
-                <?php
+				<h2>Any 5 posts with the tag of foo and the category of baz</h2>
+				<ul>
+				<?php
 
-                 foreach ( array_slice( $query->posts, 0, 5 ) as $post ) :
-                    ?><li><?php echo $post->post_title ?></li><?php
+				foreach ( array_slice( $query->posts, 0, 5 ) as $post ) :
+					?>
+					<li><?php echo $post->post_title; ?></li>
+					<?php
 				endforeach;
 			endif;
-		 	?>
+			?>
 			</ul>
 		</div>
 		<?php


### PR DESCRIPTION
Some improvements to performance, security and miscellaneous improvements:

* All output is now late-escaped
* All strings can be translated and use the textdomain properly
* Post counts are retrieved with a cached function rather than `get_posts()`
* The query is modernised with `tax_query`
* The post meta and `post__not_in` elements are removed from the query in favour of PHP-based filtering
* The overall output is cached to avoid the query where possible
* All the PHPCS issues are fixed